### PR TITLE
fix Failed parse during installPackageLI & `/s: 1: rd: not found` error

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Python 3.8 or higher is required for running this tool. So, make sure your pytho
    pip3 install -r requirements.txt
    ```
 2. Install JRE/JDK from <a href="https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html">oracle</a> if you don't have it installed. Search in Google, how to install JDK in Windows if you need more guidance on this topic. The recommended JDK version is 11.
+3. Make sure you've `zipalign` installed. You'll get it in Android SDK build-tools from <a href="https://developer.android.com/studio/releases/build-tools">here</a>. Add it to your system path.
 
 ### Termux
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ Python 3.8 or higher is required for running this tool. So, make sure your pytho
    ```bash
    pip3 install -r requirements.txt
    ```
-2. Install JRE/JDK if you don't have it installed. The recommended JDK version is 11.
+2. Install JRE/JDK & zipalign if you don't have it installed. The recommended JDK version is 17.
    ```bash
-   sudo apt-get install openjdk-11-jdk
+   sudo apt-get install openjdk-17-jdk, zipalign
    ```
 
 ### Windows


### PR DESCRIPTION
Closes #28 & small fix on `/s: 1: rd: not found` error