### PR TITLE
Export native methods using RegisterNatives

### DIFF
--- a/dex2c/compiler.py
+++ b/dex2c/compiler.py
@@ -98,13 +98,18 @@ class IrMethod(object):
         if self.writer:
             return str(self.writer)
         return ""
+    
+    def get_prototype(self):
+        if self.writer:
+            return self.writer.get_prototype()
+        return ''
 
     def __repr__(self):
         return "class IrMethod(object): %s" % self.name
 
 
 class IrBuilder(object):
-    def __init__(self, methanalysis, obfus):
+    def __init__(self, methanalysis, obfus, dynamic_register):
         method = methanalysis.get_method()
         self.method = method
         self.irmethod = None
@@ -115,6 +120,7 @@ class IrBuilder(object):
         self.var_to_name = defaultdict()
         self.offset_to_node = {}
         self.graph = None
+        self.dynamic_register = dynamic_register
 
         self.access = util.get_access_method(method.get_access_flags())
 
@@ -177,7 +183,7 @@ class IrBuilder(object):
         irmethod.params = self.lparams
         irmethod.params_type = self.params_type
 
-        writer = Writer(irmethod)
+        writer = Writer(irmethod, self.dynamic_register)
         writer.write_method()
         irmethod.writer = writer
         return irmethod
@@ -554,19 +560,21 @@ class DvMachine(object):
 
 
 class Dex2C:
-    def __init__(self, vm, vmx, obfus):
+    def __init__(self, vm, vmx, obfus, dynamic_register):
         self.vm = vm
         self.vmx = vmx
         self.obfus = obfus
+        self.dynamic_register = dynamic_register
+        
 
     def get_source_method(self, m):
         mx = self.vmx.get_method(m)
-        z = IrBuilder(mx, self.obfus)
+        z = IrBuilder(mx, self.obfus, self.dynamic_register)
         irmethod = z.process()
         if irmethod:
-            return irmethod.get_source()
+            return (irmethod.get_source(), irmethod.get_prototype())
         else:
-            return None
+            return (None, None)
 
     def get_source_class(self, _class):
         c = DvClass(_class, self.vmx)

--- a/project/jni/nc/Dex2C.cpp
+++ b/project/jni/nc/Dex2C.cpp
@@ -8,6 +8,7 @@
 #include "ScopedLocalRef.h"
 #include "ScopedPthreadMutexLock.h"
 #include "well_known_classes.h"
+#include "DynamicRegister.h"
 
 struct MemberTriple {
     MemberTriple(const char *cls_name, const char *name, const char *sig) : class_name_(cls_name),
@@ -288,5 +289,11 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
         exit(1);
 
     cache_well_known_classes(env);
+    const char *result = dynamic_register_compile_methods(env);
+    if (result != nullptr)
+    {
+        LOGD("d2c_throw_exception %s", result);
+        return JNI_ERR;
+    }
     return JNI_VERSION_1_6;
 }

--- a/project/jni/nc/DynamicRegister.h
+++ b/project/jni/nc/DynamicRegister.h
@@ -1,0 +1,8 @@
+#ifndef _DYNAMIC_REGISTER_H_ // !_DYNAMIC_REGISTER_H_
+#define _DYNAMIC_REGISTER_H_
+
+#include <jni.h>
+
+const char *dynamic_register_compile_methods(JNIEnv *env);
+
+#endif // !_DYNAMIC_REGISTER_H_


### PR DESCRIPTION
Dynamic registration for native methods. 
This add « -d, --dynamic-register » option to export native methods using RegisterNatives.

C.F https://github.com/amimo/dcc/commit/7c0d8d9fe1fa23a33ebd860b23c8c1ba773ded66